### PR TITLE
fix prom metrics

### DIFF
--- a/grpcserver/README.md
+++ b/grpcserver/README.md
@@ -28,3 +28,7 @@ grpcserver.InitAndRunGrpcServer(context.Background(), serverConfig)
 - grpc_ctxtags: adds a Tag map to context, with data populated from request body
 - grpc_zap: Integrates a zap logger into grpc handlers
 - grpc_recovery: Turns panic into grpc errors
+
+---
+
+Prometheus metrics can be accessed at `<domain>:9090`

--- a/grpcserver/config.go
+++ b/grpcserver/config.go
@@ -7,6 +7,7 @@ import (
 )
 
 type ServerConfigs struct {
+	domain                 string
 	port                   string
 	registerServerHandlers []RegisterServerHandler
 	timeout                time.Duration
@@ -19,7 +20,7 @@ type ServerConfigs struct {
 type RegisterServerHandler func(s *grpc.Server)
 
 func GetServerConfigs(
-	port string,
+	domain, port string,
 	timeout time.Duration,
 	maxIdleConn time.Duration,
 	keepAliveInterval time.Duration,
@@ -28,6 +29,7 @@ func GetServerConfigs(
 	registerServerHandlers ...RegisterServerHandler,
 ) *ServerConfigs {
 	return &ServerConfigs{
+		domain:                 domain,
 		port:                   port,
 		timeout:                timeout,
 		maxIdleConn:            maxIdleConn,
@@ -39,11 +41,12 @@ func GetServerConfigs(
 }
 
 func GetDefaultServerConfigs(
-	port string,
+	domain, port string,
 	isTest bool,
 	registerServerHandlers ...RegisterServerHandler,
 ) *ServerConfigs {
 	return &ServerConfigs{
+		domain:                 domain,
 		port:                   port,
 		timeout:                DEFAULT_KEEPALIVE_TIMEOUT,
 		maxIdleConn:            DEFAULT_MAX_IDLE_CONN,

--- a/grpcserver/constants.go
+++ b/grpcserver/constants.go
@@ -4,7 +4,7 @@ import "time"
 
 const (
 	PROMETHEUS_INTERCEPTOR_IDX = 1
-	PROMETHEUS_PORT = 9090
+	PROMETHEUS_PORT            = "9090"
 )
 
 const (

--- a/grpcserver/constants.go
+++ b/grpcserver/constants.go
@@ -4,6 +4,7 @@ import "time"
 
 const (
 	PROMETHEUS_INTERCEPTOR_IDX = 1
+	PROMETHEUS_PORT = 9090
 )
 
 const (

--- a/grpcserver/go.mod
+++ b/grpcserver/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/prometheus/client_golang v1.13.0
-	github.com/soheilhy/cmux v0.1.5
 	github.com/twothicc/common-go/logger v0.0.0-20220811074305-244cfcfaf3cf
 	go.uber.org/zap v1.21.0
 	google.golang.org/grpc v1.48.0

--- a/grpcserver/go.sum
+++ b/grpcserver/go.sum
@@ -210,8 +210,6 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
-github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
-github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -310,7 +308,6 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=

--- a/grpcserver/init.go
+++ b/grpcserver/init.go
@@ -125,28 +125,27 @@ func parseServerOptions(ctx context.Context, config *ServerConfigs) []grpc.Serve
 
 	unaryInterceptors := []grpc.UnaryServerInterceptor{
 		grpc_ctxtags.UnaryServerInterceptor(),
-		grpc_prometheus.UnaryServerInterceptor,
 		grpc_zap.UnaryServerInterceptor(logger.WithContext(ctx)),
 	}
 
 	streamInterceptors := []grpc.StreamServerInterceptor{
 		grpc_ctxtags.StreamServerInterceptor(),
-		grpc_prometheus.StreamServerInterceptor,
 		grpc_zap.StreamServerInterceptor(logger.WithContext(ctx)),
 	}
 
-	// if !config.disableProm {
-	// 	unaryInterceptors = insertIntoUnaryServerInterceptors(
-	// 		unaryInterceptors,
-	// 		grpc_prometheus.UnaryServerInterceptor,
-	// 		PROMETHEUS_INTERCEPTOR_IDX,
-	// 	)
-	// 	streamInterceptors = insertIntoStreamServerInterceptors(
-	// 		streamInterceptors,
-	// 		grpc_prometheus.StreamServerInterceptor,
-	// 		PROMETHEUS_INTERCEPTOR_IDX,
-	// 	)
-	// }
+	if !config.disableProm {
+		insertIntoUnaryServerInterceptors(
+			unaryInterceptors,
+			grpc_prometheus.UnaryServerInterceptor,
+			PROMETHEUS_INTERCEPTOR_IDX,
+		)
+
+		insertIntoStreamServerInterceptors(
+			streamInterceptors,
+			grpc_prometheus.StreamServerInterceptor,
+			PROMETHEUS_INTERCEPTOR_IDX,
+		)
+	}
 
 	return []grpc.ServerOption{
 		keepAliveParams,

--- a/grpcserver/init.go
+++ b/grpcserver/init.go
@@ -112,14 +112,11 @@ func (g *Server) ListenSignals(ctx context.Context) {
 	logger.WithContext(ctx).Info("receive signal, stop server", zap.String("signal", sig.String()))
 	time.Sleep(1 * time.Second)
 	logger.WithContext(ctx).Info("test1")
-	if g.grpcServer != nil {
-		logger.WithContext(ctx).Info("test2")
-		g.grpcServer.GracefulStop()
-	}
 
-	logger.WithContext(ctx).Info("test3")
+	logger.WithContext(ctx).Info("test2")
 
 	if g.httpServer != nil {
+		logger.WithContext(ctx).Info("test3")
 		if err := g.httpServer.Shutdown(ctx); err != nil {
 			logger.WithContext(ctx).Error("fail to gracefully shutdown http server", zap.Error(err))
 		}
@@ -127,6 +124,11 @@ func (g *Server) ListenSignals(ctx context.Context) {
 
 	if g.connMux != nil {
 		g.connMux.Close()
+	}
+
+	if g.grpcServer != nil {
+		logger.WithContext(ctx).Info("test4")
+		g.grpcServer.GracefulStop()
 	}
 
 	logger.Sync()

--- a/grpcserver/init.go
+++ b/grpcserver/init.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
+	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -126,11 +127,13 @@ func parseServerOptions(ctx context.Context, config *ServerConfigs) []grpc.Serve
 	unaryInterceptors := []grpc.UnaryServerInterceptor{
 		grpc_ctxtags.UnaryServerInterceptor(),
 		grpc_zap.UnaryServerInterceptor(logger.WithContext(ctx)),
+		grpc_recovery.UnaryServerInterceptor(),
 	}
 
 	streamInterceptors := []grpc.StreamServerInterceptor{
 		grpc_ctxtags.StreamServerInterceptor(),
 		grpc_zap.StreamServerInterceptor(logger.WithContext(ctx)),
+		grpc_recovery.StreamServerInterceptor(),
 	}
 
 	if !config.disableProm {

--- a/grpcserver/init.go
+++ b/grpcserver/init.go
@@ -97,7 +97,7 @@ func (g *Server) Run(ctx context.Context) {
 	}()
 
 	if err := m.Serve(); err != nil {
-		logger.WithContext(ctx).Error("failed to serve grpc and http server", zap.Error(err))
+
 	}
 }
 

--- a/grpcserver/init.go
+++ b/grpcserver/init.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -125,11 +126,13 @@ func parseServerOptions(ctx context.Context, config *ServerConfigs) []grpc.Serve
 	unaryInterceptors := []grpc.UnaryServerInterceptor{
 		grpc_ctxtags.UnaryServerInterceptor(),
 		grpc_prometheus.UnaryServerInterceptor,
+		grpc_zap.UnaryServerInterceptor(logger.WithContext(ctx)),
 	}
 
 	streamInterceptors := []grpc.StreamServerInterceptor{
 		grpc_ctxtags.StreamServerInterceptor(),
 		grpc_prometheus.StreamServerInterceptor,
+		grpc_zap.StreamServerInterceptor(logger.WithContext(ctx)),
 	}
 
 	// if !config.disableProm {

--- a/grpcserver/init.go
+++ b/grpcserver/init.go
@@ -97,7 +97,7 @@ func (g *Server) Run(ctx context.Context) {
 	}()
 
 	if err := m.Serve(); err != nil {
-
+		logger.WithContext(ctx).Error("fail to serve grpc and http server", zap.Error(err))
 	}
 }
 
@@ -111,22 +111,14 @@ func (g *Server) ListenSignals(ctx context.Context) {
 
 	logger.WithContext(ctx).Info("receive signal, stop server", zap.String("signal", sig.String()))
 	time.Sleep(1 * time.Second)
-	logger.WithContext(ctx).Info("test1")
-
-	if g.httpServer != nil {
-		logger.WithContext(ctx).Info("test2")
-		if err := g.httpServer.Shutdown(ctx); err != nil {
-			logger.WithContext(ctx).Error("fail to gracefully shutdown http server", zap.Error(err))
-		}
-	}
 
 	if g.grpcServer != nil {
-		logger.WithContext(ctx).Info("test3")
+		logger.WithContext(ctx).Info("test1")
 		g.grpcServer.GracefulStop()
 	}
 
 	if g.connMux != nil {
-		logger.WithContext(ctx).Info("test4")
+		logger.WithContext(ctx).Info("test2")
 		g.connMux.Close()
 	}
 

--- a/grpcserver/init.go
+++ b/grpcserver/init.go
@@ -130,8 +130,9 @@ func (g *Server) ListenSignals(ctx context.Context) {
 		logger.WithContext(ctx).Info("stop cmux server")
 	}
 
-	logger.Sync()
 	logger.WithContext(ctx).Info("stop server gracefully")
+	time.Sleep(1 * time.Second)
+	logger.Sync()
 }
 
 func parseServerOptions(ctx context.Context, config *ServerConfigs) []grpc.ServerOption {

--- a/grpcserver/init.go
+++ b/grpcserver/init.go
@@ -109,11 +109,9 @@ func (g *Server) Run(ctx context.Context) {
 		}
 	}()
 
-	go func() {
-		if err := g.connMux.Serve(); err != nil {
-			logger.WithContext(ctx).Error("fail to serve grpc and http server", zap.Error(err))
-		}
-	}()
+	if err := g.connMux.Serve(); err != nil {
+		logger.WithContext(ctx).Error("fail to serve grpc and http server", zap.Error(err))
+	}
 }
 
 // ListenSignals - listens for os signals to gracefully stop server

--- a/grpcserver/init.go
+++ b/grpcserver/init.go
@@ -134,13 +134,13 @@ func parseServerOptions(ctx context.Context, config *ServerConfigs) []grpc.Serve
 	}
 
 	if !config.disableProm {
-		insertIntoUnaryServerInterceptors(
+		unaryInterceptors = insertIntoUnaryServerInterceptors(
 			unaryInterceptors,
 			grpc_prometheus.UnaryServerInterceptor,
 			PROMETHEUS_INTERCEPTOR_IDX,
 		)
 
-		insertIntoStreamServerInterceptors(
+		streamInterceptors = insertIntoStreamServerInterceptors(
 			streamInterceptors,
 			grpc_prometheus.StreamServerInterceptor,
 			PROMETHEUS_INTERCEPTOR_IDX,

--- a/grpcserver/init.go
+++ b/grpcserver/init.go
@@ -113,22 +113,21 @@ func (g *Server) ListenSignals(ctx context.Context) {
 	time.Sleep(1 * time.Second)
 	logger.WithContext(ctx).Info("test1")
 
-	logger.WithContext(ctx).Info("test2")
-
 	if g.httpServer != nil {
-		logger.WithContext(ctx).Info("test3")
+		logger.WithContext(ctx).Info("test2")
 		if err := g.httpServer.Shutdown(ctx); err != nil {
 			logger.WithContext(ctx).Error("fail to gracefully shutdown http server", zap.Error(err))
 		}
 	}
 
-	if g.connMux != nil {
-		g.connMux.Close()
+	if g.grpcServer != nil {
+		logger.WithContext(ctx).Info("test3")
+		g.grpcServer.GracefulStop()
 	}
 
-	if g.grpcServer != nil {
+	if g.connMux != nil {
 		logger.WithContext(ctx).Info("test4")
-		g.grpcServer.GracefulStop()
+		g.connMux.Close()
 	}
 
 	logger.Sync()

--- a/grpcserver/init.go
+++ b/grpcserver/init.go
@@ -111,27 +111,24 @@ func (g *Server) ListenSignals(ctx context.Context) {
 
 	logger.WithContext(ctx).Info("receive signal, stop server", zap.String("signal", sig.String()))
 	time.Sleep(1 * time.Second)
-
+	logger.WithContext(ctx).Info("test1")
 	if g.grpcServer != nil {
+		logger.WithContext(ctx).Info("test2")
 		g.grpcServer.GracefulStop()
-		logger.WithContext(ctx).Info("stop grpc server")
 	}
+
+	logger.WithContext(ctx).Info("test3")
 
 	if g.httpServer != nil {
 		if err := g.httpServer.Shutdown(ctx); err != nil {
 			logger.WithContext(ctx).Error("fail to gracefully shutdown http server", zap.Error(err))
-		} else {
-			logger.WithContext(ctx).Info("stop http server")
 		}
 	}
 
 	if g.connMux != nil {
 		g.connMux.Close()
-		logger.WithContext(ctx).Info("stop cmux server")
 	}
 
-	logger.WithContext(ctx).Info("stop server gracefully")
-	time.Sleep(1 * time.Second)
 	logger.Sync()
 }
 

--- a/grpcserver/init.go
+++ b/grpcserver/init.go
@@ -10,8 +10,6 @@ import (
 	"syscall"
 	"time"
 
-	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
-	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -126,28 +124,26 @@ func parseServerOptions(ctx context.Context, config *ServerConfigs) []grpc.Serve
 
 	unaryInterceptors := []grpc.UnaryServerInterceptor{
 		grpc_ctxtags.UnaryServerInterceptor(),
-		grpc_zap.UnaryServerInterceptor(logger.WithContext(ctx)),
-		grpc_recovery.UnaryServerInterceptor(),
+		grpc_prometheus.UnaryServerInterceptor,
 	}
 
 	streamInterceptors := []grpc.StreamServerInterceptor{
 		grpc_ctxtags.StreamServerInterceptor(),
-		grpc_zap.StreamServerInterceptor(logger.WithContext(ctx)),
-		grpc_recovery.StreamServerInterceptor(),
+		grpc_prometheus.StreamServerInterceptor,
 	}
 
-	if !config.disableProm {
-		unaryInterceptors = insertIntoUnaryServerInterceptors(
-			unaryInterceptors,
-			grpc_prometheus.UnaryServerInterceptor,
-			PROMETHEUS_INTERCEPTOR_IDX,
-		)
-		streamInterceptors = insertIntoStreamServerInterceptors(
-			streamInterceptors,
-			grpc_prometheus.StreamServerInterceptor,
-			PROMETHEUS_INTERCEPTOR_IDX,
-		)
-	}
+	// if !config.disableProm {
+	// 	unaryInterceptors = insertIntoUnaryServerInterceptors(
+	// 		unaryInterceptors,
+	// 		grpc_prometheus.UnaryServerInterceptor,
+	// 		PROMETHEUS_INTERCEPTOR_IDX,
+	// 	)
+	// 	streamInterceptors = insertIntoStreamServerInterceptors(
+	// 		streamInterceptors,
+	// 		grpc_prometheus.StreamServerInterceptor,
+	// 		PROMETHEUS_INTERCEPTOR_IDX,
+	// 	)
+	// }
 
 	return []grpc.ServerOption{
 		keepAliveParams,

--- a/grpcserver/init.go
+++ b/grpcserver/init.go
@@ -112,11 +112,6 @@ func (g *Server) ListenSignals(ctx context.Context) {
 	logger.WithContext(ctx).Info("receive signal, stop server", zap.String("signal", sig.String()))
 	time.Sleep(1 * time.Second)
 
-	if g.connMux != nil {
-		g.connMux.Close()
-		logger.WithContext(ctx).Info("stop cmux server")
-	}
-
 	if g.grpcServer != nil {
 		g.grpcServer.GracefulStop()
 		logger.WithContext(ctx).Info("stop grpc server")
@@ -128,6 +123,11 @@ func (g *Server) ListenSignals(ctx context.Context) {
 		} else {
 			logger.WithContext(ctx).Info("stop http server")
 		}
+	}
+
+	if g.connMux != nil {
+		g.connMux.Close()
+		logger.WithContext(ctx).Info("stop cmux server")
 	}
 
 	logger.Sync()

--- a/grpcserver/init.go
+++ b/grpcserver/init.go
@@ -74,8 +74,6 @@ func InitGrpcServer(ctx context.Context, config *ServerConfigs) *Server {
 // Run - starts the grpc server.
 // Also starts http server for prometheus monitoring if specified.
 func (g *Server) Run(ctx context.Context) {
-	logger.WithContext(ctx).Info("start grpc server")
-
 	lis, err := net.Listen("tcp", fmt.Sprintf("%s:%s", g.configs.domain, g.configs.port))
 	if err != nil {
 		logger.WithContext(ctx).Fatal("fail to listen", zap.Error(err))
@@ -83,6 +81,8 @@ func (g *Server) Run(ctx context.Context) {
 
 	if g.httpServer != nil {
 		go func() {
+			logger.WithContext(ctx).Info("start http server")
+
 			if err := g.httpServer.ListenAndServe(); err != nil {
 				if !errors.Is(err, http.ErrServerClosed) {
 					logger.WithContext(ctx).Error("fail to serve http server", zap.Error(err))
@@ -92,6 +92,8 @@ func (g *Server) Run(ctx context.Context) {
 	}
 
 	if g.grpcServer != nil {
+		logger.WithContext(ctx).Info("start grpc server")
+
 		if err := g.grpcServer.Serve(lis); err != nil {
 			logger.WithContext(ctx).Error("fail to serve grpc server", zap.Error(err))
 		}

--- a/grpcserver/utils.go
+++ b/grpcserver/utils.go
@@ -1,6 +1,11 @@
 package grpcserver
 
-import "google.golang.org/grpc"
+import (
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+)
 
 func insertIntoUnaryServerInterceptors(
 	interceptors []grpc.UnaryServerInterceptor,
@@ -22,4 +27,18 @@ func insertIntoStreamServerInterceptors(
 	interceptors[idx] = interceptor
 
 	return interceptors
+}
+
+func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+	select {
+	case <-c:
+		return false // completed normally
+	case <-time.After(timeout):
+		return true // timed out
+	}
 }

--- a/grpcserver/utils.go
+++ b/grpcserver/utils.go
@@ -6,20 +6,16 @@ func insertIntoUnaryServerInterceptors(
 	interceptors []grpc.UnaryServerInterceptor,
 	interceptor grpc.UnaryServerInterceptor,
 	idx int,
-) []grpc.UnaryServerInterceptor {
+) {
 	interceptors = append(interceptors[:idx+1], interceptors[idx:]...)
 	interceptors[idx] = interceptor
-
-	return interceptors
 }
 
 func insertIntoStreamServerInterceptors(
 	interceptors []grpc.StreamServerInterceptor,
 	interceptor grpc.StreamServerInterceptor,
 	idx int,
-) []grpc.StreamServerInterceptor {
+) {
 	interceptors = append(interceptors[:idx+1], interceptors[idx:]...)
 	interceptors[idx] = interceptor
-
-	return interceptors
 }

--- a/grpcserver/utils.go
+++ b/grpcserver/utils.go
@@ -1,9 +1,6 @@
 package grpcserver
 
 import (
-	"sync"
-	"time"
-
 	"google.golang.org/grpc"
 )
 
@@ -27,18 +24,4 @@ func insertIntoStreamServerInterceptors(
 	interceptors[idx] = interceptor
 
 	return interceptors
-}
-
-func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
-	c := make(chan struct{})
-	go func() {
-		defer close(c)
-		wg.Wait()
-	}()
-	select {
-	case <-c:
-		return false // completed normally
-	case <-time.After(timeout):
-		return true // timed out
-	}
 }

--- a/grpcserver/utils.go
+++ b/grpcserver/utils.go
@@ -6,16 +6,20 @@ func insertIntoUnaryServerInterceptors(
 	interceptors []grpc.UnaryServerInterceptor,
 	interceptor grpc.UnaryServerInterceptor,
 	idx int,
-) {
+) []grpc.UnaryServerInterceptor {
 	interceptors = append(interceptors[:idx+1], interceptors[idx:]...)
 	interceptors[idx] = interceptor
+
+	return interceptors
 }
 
 func insertIntoStreamServerInterceptors(
 	interceptors []grpc.StreamServerInterceptor,
 	interceptor grpc.StreamServerInterceptor,
 	idx int,
-) {
+) []grpc.StreamServerInterceptor {
 	interceptors = append(interceptors[:idx+1], interceptors[idx:]...)
 	interceptors[idx] = interceptor
+
+	return interceptors
 }


### PR DESCRIPTION
Addresses #10 
Change to not use cmux because it is difficult to manage graceful stopping and that it is not necessary to run both http and grpc server at the same port.